### PR TITLE
Implement loop fuse scheduling directive

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -646,6 +646,11 @@ public:
   IndexStmt divide(IndexVar i, IndexVar i1, IndexVar i2, size_t divideFactor) const; // TODO: TailStrategy
 
 
+  /// The loopfuse transformation fuses common outer loops in 
+  /// 2 iteration graphs. 
+  IndexStmt loopfuse(int pos, bool isProducerOnLeft, std::vector<int>& path) const;
+
+
   /// The reorder transformation swaps two directly nested index
   /// variables in an iteration graph.  This changes the order of
   /// iteration through the space and the order of tensor accesses.

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -1325,6 +1325,8 @@ std::vector<TensorVar> getAttrQueryResults(IndexStmt stmt);
 /// Returns the temporaries in the index statement, in the order they appear.
 std::map<Forall, Where> getTemporaryLocations(IndexStmt stmt);
 
+std::vector<Where> getTemporaryInitializationOrder(IndexStmt stmt);
+
 /// Returns the results in the index statement that should be assembled by 
 /// ungrouped insertion.
 std::vector<TensorVar> getAssembledByUngroupedInsertion(IndexStmt stmt);

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -675,6 +675,9 @@ public:
   /// reorder takes a new ordering for a set of index variables that are directly nested in the iteration order
   IndexStmt reorder(std::vector<IndexVar> reorderedvars) const;
 
+  /// reorders the index variables in a nested structure with where clauses
+  IndexStmt reorder(std::vector<int> path, std::vector<IndexVar> reorderedvars) const;
+
   /// The mergeby transformation specifies how to merge iterators on
   /// the given index variable. By default, if an iterator is used for windowing
   /// it will be merged with the "gallop" strategy.

--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -647,7 +647,14 @@ public:
 
 
   /// The loopfuse transformation fuses common outer loops in 
-  /// 2 iteration graphs. 
+  /// 2 iteration graphs.
+  /// when performing loopfuse operation on an already branched index statement
+  /// eg: forall(l, where(forall(ijk, T(j,k) += A*B), forall(mjkn, X(l,m,n) += T*C*D)))
+  /// and we want to further breakdown T*C*D into T2 = T*C and T2*D
+  /// we can use the path vector to specify the branch we want to apply the fuse on
+  /// eg: loopfuse(2, true, {1}) where 2 refers to breaking T*C*D at the 2nd position
+  /// and true refers to making T*C as the producer (if false, then C*D will be the producer if used with 1)
+  /// and {1} refers to the branch we want to apply the fuse on
   IndexStmt loopfuse(int pos, bool isProducerOnLeft, std::vector<int>& path) const;
 
 

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -17,6 +17,7 @@ class IndexStmt;
 class TransformationInterface;
 class Reorder;
 class Precompute;
+class LoopFuse;
 class ForAllReplace;
 class AddSuchThatPredicates;
 class Parallelize;
@@ -32,6 +33,7 @@ class Transformation {
 public:
   Transformation(Reorder);
   Transformation(Precompute);
+  Transformation(LoopFuse);
   Transformation(ForAllReplace);
   Transformation(Parallelize);
   Transformation(TopoReorder);
@@ -114,6 +116,28 @@ private:
 /// Print a precompute command.
 std::ostream &operator<<(std::ostream &, const Precompute &);
 
+/// The loopfuse optimization rewrite an index expression to precompute 
+/// part of the `expr` and store it to a workspace. 
+class LoopFuse : public TransformationInterface {
+public:
+  LoopFuse();
+  LoopFuse(int pos, bool isProducerOnLeft, std::vector<int>& path);
+
+  int getPos() const;
+  bool getIsProducerOnLeft() const;
+  std::vector<int>& getPath() const;
+
+  /// Apply the loopfuse optimization to a concrete index statement.
+  IndexStmt apply(IndexStmt, std::string *reason = nullptr) const;
+
+  void print(std::ostream &os) const;
+
+private:
+  struct Content;
+  std::shared_ptr<Content> content;
+};
+
+std::ostream &operator<<(std::ostream &, const LoopFuse &);
 
 /// Replaces all occurrences of directly nested forall nodes of pattern with
 /// directly nested loops of replacement

--- a/include/taco/index_notation/transformations.h
+++ b/include/taco/index_notation/transformations.h
@@ -67,10 +67,12 @@ class Reorder : public TransformationInterface {
 public:
   Reorder(IndexVar i, IndexVar j);
   Reorder(std::vector<IndexVar> replacePattern);
+  Reorder(std::vector<int> path, std::vector<IndexVar> replacePattern);
 
   IndexVar geti() const;
   IndexVar getj() const;
   const std::vector<IndexVar>& getreplacepattern() const;
+  const std::vector<int>& getpath() const;
 
   /// Apply the reorder optimization to a concrete index statement.  Returns
   /// an undefined statement and a reason if the statement cannot be lowered.
@@ -146,6 +148,9 @@ public:
   ForAllReplace();
 
   ForAllReplace(std::vector<IndexVar> pattern, std::vector<IndexVar> replacement);
+  ForAllReplace(std::vector<int> path, std::vector<IndexVar> pattern, std::vector<IndexVar> replacement);
+
+  std::vector<int> getPath() const;
 
   std::vector<IndexVar> getPattern() const;
 

--- a/include/taco/lower/lowerer_impl_imperative.h
+++ b/include/taco/lower/lowerer_impl_imperative.h
@@ -513,7 +513,9 @@ private:
   std::set<ir::Expr> nonFullyInitializedResults;
 
   /// Map used to hoist temporary workspace initialization
-  std::map<Forall, Where> temporaryInitialization;
+  std::vector<Where> temporaryInitializationOrder;
+  std::set<Where> temporaryInitializationDone;
+  std::vector<ParallelUnit> loopParallelUnits;
 
   /// Map used to hoist parallel temporary workspaces. Maps workspace shared by all threads to where statement
   std::map<Where, TensorVar> whereToTemporaryVar;

--- a/include/taco/parser/lexer.h
+++ b/include/taco/parser/lexer.h
@@ -22,6 +22,7 @@ enum class Token {
   sub,
   mul,
   div,
+  colon,
   eq,
   eot,  // End of tokens
   error

--- a/include/taco/parser/lexer.h
+++ b/include/taco/parser/lexer.h
@@ -22,7 +22,7 @@ enum class Token {
   sub,
   mul,
   div,
-  colon,
+  colon, // numbers before the colon indicate the path to branch in a branched iteration graph
   eq,
   eot,  // End of tokens
   error

--- a/include/taco/tensor.h
+++ b/include/taco/tensor.h
@@ -429,6 +429,7 @@ public:
 
   /// Compute the given expression and put the values in the tensor storage.
   void compute();
+  void compute(IndexStmt stmt);
 
   /// Compile, assemble and compute as needed.
   void evaluate();

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1854,6 +1854,26 @@ IndexStmt IndexStmt::divide(IndexVar i, IndexVar i1, IndexVar i2, size_t splitFa
   return transformed;
 }
 
+IndexStmt IndexStmt::loopfuse(int pos, bool isProducerOnLeft, vector<int>& path) const {
+
+  std::cout << "Loop fuse pos: " << pos;
+  std::cout << ", Loop fuse isProducerOnLeft: " << isProducerOnLeft;
+  for (const auto& p : path) {
+    std::cout << " " << p;
+  }
+  std::cout << std::endl;
+
+  string reason;
+  IndexStmt transformed = *this;
+  transformed = Transformation(LoopFuse(pos, isProducerOnLeft, path)).apply(transformed, &reason);
+  if (!transformed.defined()) {
+    taco_uerror << reason;
+  }
+  return transformed;
+
+  return *this;
+}
+
 IndexStmt IndexStmt::precompute(IndexExpr expr, std::vector<IndexVar> i_vars,
                                 std::vector<IndexVar> iw_vars, TensorVar workspace) const {
 
@@ -2047,6 +2067,7 @@ IndexStmt IndexStmt::assemble(TensorVar result, AssembleStrategy strategy,
   }
   return transformed;
 }
+
 
 IndexStmt IndexStmt::wsaccel(TensorVar& ws, bool shouldAccel, const std::vector<IndexVar>& accelIndexVars) {
     if (accelIndexVars.size() == 0) {

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -3490,6 +3490,23 @@ std::map<Forall, Where> getTemporaryLocations(IndexStmt stmt) {
   return temporaryLocs;
 }
 
+std::vector<Where> getTemporaryInitializationOrder(IndexStmt stmt) {
+  struct TemporaryLocsGetter : public IndexNotationVisitor {
+    vector<Where> temporaryOrder;
+
+    using IndexNotationVisitor::visit;
+
+    void visit(const WhereNode *op) {
+      Where where = Where(op);
+      temporaryOrder.push_back(where);
+      IndexNotationVisitor::visit(op);
+    }
+  };
+  TemporaryLocsGetter getter;
+  getter.visit(stmt);
+
+  return getter.temporaryOrder;
+}
 
 std::vector<TensorVar> getTemporaries(IndexStmt stmt) {
   vector<TensorVar> temporaries;

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1855,14 +1855,6 @@ IndexStmt IndexStmt::divide(IndexVar i, IndexVar i1, IndexVar i2, size_t splitFa
 }
 
 IndexStmt IndexStmt::loopfuse(int pos, bool isProducerOnLeft, vector<int>& path) const {
-
-  std::cout << "Loop fuse pos: " << pos;
-  std::cout << ", Loop fuse isProducerOnLeft: " << isProducerOnLeft;
-  for (const auto& p : path) {
-    std::cout << " " << p;
-  }
-  std::cout << std::endl;
-
   string reason;
   IndexStmt transformed = *this;
   transformed = Transformation(LoopFuse(pos, isProducerOnLeft, path)).apply(transformed, &reason);

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -1919,6 +1919,15 @@ IndexStmt IndexStmt::reorder(std::vector<IndexVar> reorderedvars) const {
   return transformed;
 }
 
+IndexStmt IndexStmt::reorder(std::vector<int> path, std::vector<IndexVar> reorderedvars) const {
+  string reason;
+  IndexStmt transformed = Reorder(path, reorderedvars).apply(*this, &reason);
+  if (!transformed.defined()) {
+    taco_uerror << reason;
+  }
+  return transformed;
+}
+
 IndexStmt IndexStmt::mergeby(IndexVar i, MergeStrategy strategy) const {
   string reason;
   IndexStmt transformed = SetMergeStrategy(i, strategy).apply(*this, &reason);

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -485,7 +485,11 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
   };
   populateDimension(getProducerAndConsumer.varTypes);
   Access resultAccess = to<Access>(getProducerAndConsumer.result);
-  TensorVar intermediateTensor("t_" + resultAccess.getTensorVar().getName(), Type(Float64, temporaryDims));
+  string path = "";
+  for (auto& p : getPath()) {
+    path += to_string(p);
+  }
+  TensorVar intermediateTensor("t_" + resultAccess.getTensorVar().getName() + path, Type(Float64, temporaryDims));
   Access workspace(intermediateTensor, temporaryVars);
 
   Assignment producerAssignment(workspace, getProducerAndConsumer.producer, getAssignment.innerAssignment.getOperator());

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -4,6 +4,7 @@
 #include "taco/index_notation/index_notation_rewriter.h"
 #include "taco/index_notation/index_notation_nodes.h"
 #include "taco/error/error_messages.h"
+#include "taco/index_notation/index_notation_visitor.h"
 #include "taco/storage/index.h"
 #include "taco/util/collections.h"
 #include "taco/lower/iterator.h"
@@ -288,6 +289,7 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
     Assignment innerAssignment;
     vector<IndexVar> indexAccessVars;
     vector<IndexVar> indexVarsUntilBranch;
+    vector<IndexVar> indexVarsAfterBranch;
     unsigned int pathIdx = 0;
     vector<int> path;
 
@@ -300,6 +302,9 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
       indexAccessVars.push_back(forall.getIndexVar());
       if (pathIdx < path.size()) {
         indexVarsUntilBranch.push_back(forall.getIndexVar());
+      }
+      if (pathIdx >= path.size()) {
+        indexVarsAfterBranch.push_back(forall.getIndexVar());
       }
 
       if (isa<Assignment>(forall.getStmt())) {
@@ -454,7 +459,7 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
 
   // check if there are common outer loops in producerAccessOrder and consumerAccessOrder
   vector<IndexVar> commonLoopVars;
-  for (auto& var : getAssignment.indexAccessVars) {
+  for (auto& var : getAssignment.indexVarsAfterBranch) {
     auto itC = find(consumerLoopVars.begin(), consumerLoopVars.end(), var);
     auto itP = find(producerLoopVars.begin(), producerLoopVars.end(), var);
     if (itC != consumerLoopVars.end() && itP != producerLoopVars.end()) {

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -504,9 +504,9 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
   // multiplying workspace * consumer and if the producer is on right, 
   // then the consumer is constructed by multiplying consumer * workspace
   if (!getIsProducerOnLeft()) {
-    consumerAssignment = Assignment(to<Access>(getProducerAndConsumer.result), getProducerAndConsumer.consumer * workspace, getAssignment.innerAssignment.getOperator());
+    consumerAssignment = Assignment(to<Access>(getProducerAndConsumer.result), getProducerAndConsumer.consumer == NULL ? workspace : getProducerAndConsumer.consumer * workspace, getAssignment.innerAssignment.getOperator());
   } else {
-    consumerAssignment = Assignment(to<Access>(getProducerAndConsumer.result), workspace * getProducerAndConsumer.consumer, getAssignment.innerAssignment.getOperator());
+    consumerAssignment = Assignment(to<Access>(getProducerAndConsumer.result), getProducerAndConsumer.consumer == NULL ? workspace : workspace * getProducerAndConsumer.consumer, getAssignment.innerAssignment.getOperator());
   }
 
   // rewrite the index notation to use the temporary

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -479,8 +479,6 @@ IndexStmt LoopFuse::apply(IndexStmt stmt, std::string* reason) const {
 
     void visit(const WhereNode* node) {
       Where where(node);
-      cout << "Where: " << where << endl;
-
       // select the path to visit
       if (!path[pathIdx]) { // if path[pathIdx] == 0, go to the producer
         pathIdx++;

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -84,6 +84,9 @@ Token Lexer::getToken() {
     case '/':
       token = Token::div;
       break;
+    case ';':
+      token = Token::colon;
+      break;
     case '=':
       token = Token::eq;
       break;

--- a/src/parser/schedule_parser.cpp
+++ b/src/parser/schedule_parser.cpp
@@ -52,6 +52,10 @@ vector<vector<string>> ScheduleParser(const string argValue) {
                 current_element += lexer.tokenString(tok);
             parenthesesCnt--;
             break;
+        case parser::Token::colon:
+            current_schedule.push_back(current_element);
+            current_element = "";
+            break;
         case parser::Token::comma:
             if (curlyParenthesesCnt > 0) {
               // multiple indexes inside of a {} list; pass it through

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -775,6 +775,42 @@ static inline map<TensorVar, TensorBase> getTensors(const IndexExpr& expr) {
   return getOperands.arguments;
 }
 
+static inline map<TensorVar, TensorBase> getTensors(const IndexStmt& stmt, vector<TensorVar>& operands) {
+  struct GetOperands : public IndexNotationVisitor {
+    using IndexNotationVisitor::visit;
+    vector<TensorVar>& operands;
+    map<TensorVar, TensorBase> arguments;
+
+    GetOperands(vector<TensorVar>& operands) : operands(operands) {}
+
+    void visit(const AccessNode* node) {
+      Access access = Access(node);
+      if (!isa<AccessTensorNode>(node)) {
+        return; // temporary ignore
+      }
+      Access ac = Access(node);
+      taco_iassert(isa<AccessTensorNode>(node)) << "Unknown subexpression";
+
+      if (!util::contains(arguments, node->tensorVar)) {
+        arguments.insert({node->tensorVar, to<AccessTensorNode>(node)->tensor});
+        operands.push_back(node->tensorVar);
+      }
+
+      // Also add any tensors backing index sets of tensor accesses.
+      for (auto& p : node->indexSetModes) {
+        auto tv = p.second.tensor.getTensorVar();
+        if (!util::contains(arguments, tv)) {
+          arguments.insert({tv, p.second.tensor});
+          operands.push_back(tv);
+        }
+      }
+    }
+  };
+  GetOperands getOperands(operands);
+  stmt.accept(&getOperands);
+  return getOperands.arguments;
+}
+
 static inline
 vector<void*> packArguments(const TensorBase& tensor) {
   vector<void*> arguments;
@@ -797,6 +833,35 @@ vector<void*> packArguments(const TensorBase& tensor) {
   auto operands = getArguments(makeConcreteNotation(tensor.getAssignment()));
 
   auto tensors = getTensors(tensor.getAssignment().getRhs());
+  for (auto& operand : operands) {
+    taco_iassert(util::contains(tensors, operand));
+    arguments.push_back(tensors.at(operand).getStorage());
+  }
+
+  return arguments;
+}
+
+static inline
+vector<void*> packArguments(const TensorBase& tensor, const IndexStmt stmt) {
+  vector<void*> arguments;
+
+  // Pack the result tensor
+  arguments.push_back(tensor.getStorage());
+
+  // Pack any index sets on the result tensor at the front of the arguments list.
+  auto lhs = getNode(tensor.getAssignment().getLhs());
+  // We check isa<AccessNode> rather than isa<AccessTensorNode> to catch cases
+  // where the underlying access is represented with the base AccessNode class.
+  if (isa<AccessNode>(lhs)) {
+    auto indexSetModes = to<AccessNode>(lhs)->indexSetModes;
+    for (auto& it : indexSetModes) {
+      arguments.push_back(it.second.tensor.getStorage());
+    }
+  }
+
+  // Pack operand tensors
+  std::vector<TensorVar> operands;
+  auto tensors = getTensors(stmt, operands);
   for (auto& operand : operands) {
     taco_iassert(util::contains(tensors, operand));
     arguments.push_back(tensors.at(operand).getStorage());
@@ -840,6 +905,29 @@ void TensorBase::compute() {
   }
 
   auto arguments = packArguments(*this);
+  this->content->module->callFuncPacked("compute", arguments.data());
+
+  if (content->assembleWhileCompute) {
+    setNeedsAssemble(false);
+    taco_tensor_t* tensorData = ((taco_tensor_t*)arguments[0]);
+    content->valuesSize = unpackTensorData(*tensorData, *this);
+  }
+}
+
+void TensorBase::compute(IndexStmt stmt) {
+    taco_uassert(!needsCompile()) << error::compute_without_compile;
+  if (!needsCompute()) {
+    return;
+  }
+  setNeedsCompute(false);
+  // Sync operand tensors if needed.
+  auto operands = getTensors(getAssignment().getRhs());
+  for (auto& operand : operands) {
+    operand.second.syncValues();
+    operand.second.removeDependentTensor(*this);
+  }
+
+  auto arguments = packArguments(*this, stmt);
   this->content->module->callFuncPacked("compute", arguments.data());
 
   if (content->assembleWhileCompute) {

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -858,6 +858,60 @@ TEST(workspaces, loopcontractfuse) {
   ASSERT_TENSOR_EQ(expected, A);
 }
 
+TEST(workspaces, loopreordercontractfuse) {
+  int N = 16;
+  Tensor<double> A("A", {N, N, N}, Format{Dense, Dense, Dense});
+  Tensor<double> B("B", {N, N, N}, Format{Dense, Sparse, Sparse});
+  Tensor<double> C("C", {N, N}, Format{Dense, Dense});
+  Tensor<double> D("D", {N, N}, Format{Dense, Dense});
+  Tensor<double> E("E", {N, N}, Format{Dense, Dense});
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < N; k++) {
+        B.insert({i, j, k}, (double) i);
+      }
+      C.insert({i, j}, (double) j);
+      E.insert({i, j}, (double) i*j);
+      D.insert({i, j}, (double) i*j);
+    }
+  }
+
+  IndexVar i("i"), j("j"), k("k"), l("l"), m("m"), n("n");
+  A(l,m,n) = B(i,j,k) * C(i,l) * D(j,m) * E(k,n);
+
+  IndexStmt stmt = A.getAssignment().concretize();
+
+  std::cout << stmt << endl;
+  vector<int> path1;
+  vector<int> path2 = {1};
+  stmt = stmt
+    .reorder({l,i,m, j, k, n})
+    .loopfuse(2, true, path1)
+    .reorder(path2, {m,k,j,n})
+    .loopfuse(2, true, path2)
+    ;
+  stmt = stmt
+    .parallelize(l, ParallelUnit::CPUThread, OutputRaceStrategy::NoRaces)
+    ;
+
+
+  stmt = stmt.concretize();
+  cout << "final stmt: " << stmt << endl;
+  printCodeToFile("loopreordercontractfuse", stmt);
+
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", {N, N, N}, Format{Dense, Dense, Dense});
+  expected(l,m,n) = B(i,j,k) * C(i,l) * D(j,m) * E(k,n);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(expected, A);
+}
+
 TEST(workspaces, precompute2D_mul) {
   int N = 16;
   Tensor<double> A("A", {N, N}, Format{Dense, Dense});

--- a/test/tests-workspaces.cpp
+++ b/test/tests-workspaces.cpp
@@ -754,6 +754,56 @@ TEST(workspaces, loopreversefuse) {
   ASSERT_TENSOR_EQ(expected, A);
 }
 
+TEST(workspaces, loopfusesddmm) {
+  int N = 16;
+  float SPARSITY = 0.3;
+  vector<int> dims{N,N};
+  const IndexVar i("i"), j("j"), k("k"), l("l");
+
+  Tensor<double> A("A", dims, Format{Dense, Dense});
+  Tensor<double> B("B", dims, Format{Dense, Sparse});
+  Tensor<double> C("C", dims, Format{Dense, Dense});
+  Tensor<double> D("D", dims, Format{Dense, Dense});
+
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < N; j++) {
+      float rand_float = (float) rand() / (float) RAND_MAX;
+      if (rand_float < SPARSITY)
+        B.insert({i, j}, (double) i);
+      C.insert({i, j}, (double) j);
+      D.insert({i, j}, (double) i*j);
+    }
+  }
+
+  A(i,j) = B(i,j) * C(i,k) * D(j,k);
+
+  IndexStmt stmt = A.getAssignment().concretize();
+
+  vector<int> path1;
+  stmt = stmt
+    .reorder({i,k,j});
+  stmt = stmt
+    .loopfuse(3, true, path1);
+  stmt = stmt
+    .parallelize(i, ParallelUnit::CPUThread, OutputRaceStrategy::NoRaces)
+    ;
+
+  stmt = stmt.concretize();
+  cout << "final stmt: " << stmt << endl;
+  printCodeToFile("loopfusesddmm", stmt);
+
+  A.compile(stmt.concretize());
+  A.assemble();
+  A.compute();
+
+  Tensor<double> expected("expected", dims, Format{Dense, Dense});
+  expected(i,j) = B(i,j) * C(i,k) * D(j,k);
+  expected.compile();
+  expected.assemble();
+  expected.compute();
+  ASSERT_TENSOR_EQ(expected, A);
+}
+
 
 TEST(workspaces, loopcontractfuse) {
   int N = 16;

--- a/tools/taco.cpp
+++ b/tools/taco.cpp
@@ -123,6 +123,12 @@ static void printUsageInfo() {
             "-help=scheduling for a list of scheduling commands. "
             "Examples: split(i,i0,i1,16), precompute(A(i,j)*x(j),i,i).");
   cout << endl;
+  printFlag("s=\"loopfuse(<branch separated by comma>;<position inside the branch>)\"",
+            "Specify the loopfuse command to apply fusion directive to the code. "
+            "Parameters take on the form of a comma-delimited list, separated by a colon, "
+            "And the branching point. See -help=loopfuse for a list of loopfuse commands. "
+            "Examples: loopfuse(3).loopfuse(1;2).loopfuse(2;2).loopfuse(1,1;1).");
+  cout << endl;
   printFlag("c",
             "Generate compute kernel that simultaneously does assembly.");
   cout << endl;
@@ -351,6 +357,23 @@ static bool setSchedulingCommands(vector<vector<string>> scheduleCommands, parse
 
       IndexVar fused(f);
       stmt = stmt.fuse(findVar(i), findVar(j), fused);
+
+    } else if (command == "loopfuse") {
+      taco_uassert(scheduleCommand.size() >= 1)
+        << "'loopfuse' scheduling directive takes more than 1 parameter; loopfuse(1)";
+      cout << "loopfuse directive found\n";
+
+      vector<int> path;
+      transform(scheduleCommand.begin(), scheduleCommand.end(), back_inserter(path),
+        [&](std::string &s) { return stoi(s); });
+      int split = path.back();
+      if (path.size() > 1) path.pop_back();
+      cout << "split: " << split << endl;
+      for (unsigned int i=0; i<path.size(); i++) {
+        cout << i << ": " << path[i] << endl;
+      }
+
+      // stmt = stmt.
 
     } else if (command == "split") {
       taco_uassert(scheduleCommand.size() == 4)
@@ -1020,6 +1043,7 @@ int main(int argc, char* argv[]) {
       printKernels = true;
     }
     else if ("-s" == argName) {
+      cout << "argName: " << argName << ", argValue: " << argValue << endl;
       setSchedule = true;
       vector<vector<string>> parsed = parser::ScheduleParser(argValue);
 


### PR DESCRIPTION
Build TACO 

```
mkdir build
cd build
make -j 8

# run the below command to generate loop fused code
# fusion with the left part as producer and the right part as consumer
./bin/taco-test "workspaces.loopfuse"

# fusion with the left part as consumer and the right part as producer
./bin/taco-test "workspaces.loopreversefuse"

# iterative fusion
./bin/taco-test "workspaces.loopcontractfuse"

# iterative fusion with local reordering in the middle
./bin/taco-test "workspaces.loopreordercontractfuse"

# fusion of a whole expression (not splitting in the middle)
./bin/taco-test "workspaces.loopfusesddmm"
```

The fused code is saved to;
```
build/eval_generated/loopfuse.c
build/eval_generated/loopreversefuse.c
etc
```

I am working on adding more test cases